### PR TITLE
cg_draw.cpp additions

### DIFF
--- a/code/cgame/cg_draw.cpp
+++ b/code/cgame/cg_draw.cpp
@@ -3364,35 +3364,55 @@ static std::string FloatToString(float value, int precision){
 // Array needed to know what the maximum height is
 extern float forceJumpHeight[];
 // The function
-static void CG_DrawPlayerInfo(int precision) {
+static float CG_DrawPlayerInfo(float x, float y, int precision) {
 	// cg_drawPlayerInfo between 0 and 7 will give different results depending on which bit is set to customize what we want to see.
 	gentity_t const* player_gent = cg_entities[cg.snap->ps.clientNum].gent;
-	const int pos_x_string = 8; // little offset to not be all the way on the left
-	int y = 16; // little offset to still have the console print everything
+	const int pos_x_string = x;
+
 	// Precision boundaries
 	if (precision < 0) precision = 0;
 	if (precision > 5) precision = 5;
 
-	if (cg_drawPlayerInfo.integer & 0b1)
+	// Filters consts
+	const int info_filter_position = 1 << 0;
+	const int info_filter_velocity = 1 << 1;
+	const int info_filter_angles = 1 << 2;
+	const int info_filter_jump = 1 << 3;
+
+	if (cg_drawPlayerInfo.integer & info_filter_position)
 	{
 		///// POSITION /////
 		const std::string positionWord = "Position";
-		std::string pos_x = "X : " + FloatToString(player_gent->client->ps.origin[0], precision);
-		std::string pos_y = "Y : " + FloatToString(player_gent->client->ps.origin[1], precision);
-		std::string pos_z = "Z : " + FloatToString(player_gent->client->ps.origin[2], precision);
 
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, positionWord.c_str(), colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+
+		std::string pos_x = "P_X : " + FloatToString(player_gent->client->ps.origin[0], precision);
+		std::string pos_y = "P_Y : " + FloatToString(player_gent->client->ps.origin[1], precision);
+		std::string pos_z = "P_Z : " + FloatToString(player_gent->client->ps.origin[2], precision);
+
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, pos_x.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, pos_y.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, pos_z.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+
+		std::string eye_x = "E_X : " + FloatToString(player_gent->client->renderInfo.eyePoint[0], precision);
+		std::string eye_y = "E_Y : " + FloatToString(player_gent->client->renderInfo.eyePoint[1], precision);
+		std::string eye_z = "E_Z : " + FloatToString(player_gent->client->renderInfo.eyePoint[2], precision);
+
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, eye_x.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, eye_y.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, eye_z.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+
 		///// POSITION /////
 	}
 
-	if (cg_drawPlayerInfo.integer & 0b10)
+	if (cg_drawPlayerInfo.integer & info_filter_velocity)
 	{
 		///// VELOCITY /////
 		const std::string velocityWord = "Velocity";
@@ -3400,25 +3420,41 @@ static void CG_DrawPlayerInfo(int precision) {
 		std::string vel_y = "Y : " + FloatToString(player_gent->client->ps.velocity[1], precision);
 		std::string vel_z = "Z : " + FloatToString(player_gent->client->ps.velocity[2], precision);
 
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, velocityWord.c_str(), colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, vel_x.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, vel_y.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, vel_z.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
 		///// VELOCITY /////
 	}
 
-	if (cg_drawPlayerInfo.integer & 0b100)// && g_cheats->integer)
+	if (cg_drawPlayerInfo.integer & info_filter_angles)
+	{
+		///// ANGLE /////
+		const std::string angleWord = "Angles";
+		std::string ang_v = "V : " + FloatToString(player_gent->client->ps.viewangles[0], precision);
+		std::string ang_h = "H : " + FloatToString(player_gent->client->ps.viewangles[1], precision);
+
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, angleWord.c_str(), colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, ang_v.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(pos_x_string, y + 2, ang_h.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		///// ANGLE /////
+	}
+
+	if (cg_drawPlayerInfo.integer & info_filter_jump)
 	{
 		///// JUMPING /////
 		const std::string jumpWord = "Jump";
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		cgi_R_Font_DrawString(pos_x_string, y + 2, jumpWord.c_str(), colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
 		
-		y = y + 16;
+		y = y + BIGCHAR_HEIGHT;
 		if (player_gent->client->ps.forceJumpZStart == 0.0)
 		{
 			std::string jumpPositions = FloatToString(forceJumpHeight[player_gent->client->ps.forcePowerLevel[FP_LEVITATION]], precision) + " | N/A";
@@ -3433,12 +3469,171 @@ static void CG_DrawPlayerInfo(int precision) {
 				+ FloatToString(player_gent->client->ps.origin[2] - player_gent->client->ps.forceJumpZStart + (player_gent->client->ps.velocity[2] * 0.008), precision);;
 			cgi_R_Font_DrawString(pos_x_string, y + 2, jumpPositions.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
 
-			y = y + 16;
+			y = y + BIGCHAR_HEIGHT;
 			cgi_R_Font_DrawString(pos_x_string, y + 2, "Jumping", colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
 		}
 		///// JUMPING /////
 	}
+
+	return y + BIGCHAR_HEIGHT;
 }
+
+
+/*
+===========================
+CG_DrawNPCInfo
+===========================
+*/
+// Function to keep track of the last valid entity we got, so that even when not looking at one, we keep the pointer
+static gentity_t* GetLastCrosshairNPC()
+{
+	static gentity_t* validNPCPointer = nullptr;
+
+	// First check : when dying, NPC lose it's pointer
+	if (validNPCPointer && !validNPCPointer->NPC)
+	{
+		validNPCPointer = nullptr;
+	}
+	// Second check : when looking at an NPC, update the pointer
+	gentity_t* temp = &g_entities[g_crosshairEntNum];
+	if (temp && temp->NPC)
+	{
+		validNPCPointer = temp;
+	}
+
+	return validNPCPointer;
+}
+static const char* NPCBehaviorName(bState_t x)
+{
+	switch (x)
+	{
+	case BS_ADVANCE_FIGHT:     return "BS_ADVANCE_FIGHT";
+	case BS_SLEEP:             return "BS_SLEEP";
+	case BS_FOLLOW_LEADER:     return "BS_FOLLOW_LEADER";
+	case BS_JUMP:              return "BS_JUMP";
+	case BS_SEARCH:            return "BS_SEARCH";
+	case BS_WANDER:            return "BS_WANDER";
+	case BS_NOCLIP:            return "BS_NOCLIP";
+	case BS_REMOVE:            return "BS_REMOVE";
+	case BS_CINEMATIC:         return "BS_CINEMATIC";
+	case BS_WAIT:              return "BS_WAIT";
+	case BS_STAND_GUARD:       return "BS_STAND_GUARD";
+	case BS_PATROL:            return "BS_PATROL";
+	case BS_INVESTIGATE:       return "BS_INVESTIGATE";
+	case BS_STAND_AND_SHOOT:   return "BS_STAND_AND_SHOOT";
+	case BS_HUNT_AND_KILL:     return "BS_HUNT_AND_KILL";
+	case BS_FLEE:              return "BS_FLEE";
+	default:                   return nullptr; // BS_DEFAULT, keep empty ?
+	}
+}
+static const char* NPCSquadName(int x)
+{
+	switch (x)
+	{
+	case SQUAD_IDLE:            return "SQUAD_IDLE";
+	case SQUAD_STAND_AND_SHOOT: return "SQUAD_STAND_AND_SHOOT";
+	case SQUAD_RETREAT:         return "SQUAD_RETREAT";
+	case SQUAD_COVER:           return "SQUAD_COVER";
+	case SQUAD_TRANSITION:      return "SQUAD_TRANSITION";
+	case SQUAD_POINT:           return "SQUAD_POINT";
+	case SQUAD_SCOUT:           return "SQUAD_SCOUT";
+	default:                    return "";
+	}
+}
+struct AIFlagPair { int flag; const char* name; };
+static AIFlagPair aiFlags[] = {
+	{ NPCAI_CHECK_WEAPON,       "- NPCAI_CHECK_WEAPON" },
+	{ NPCAI_BURST_WEAPON,       "- NPCAI_BURST_WEAPON" },
+	{ NPCAI_MOVING,             "- NPCAI_MOVING" },
+	{ NPCAI_TOUCHED_GOAL,       "- NPCAI_TOUCHED_GOAL" },
+	{ NPCAI_PUSHED,             "- NPCAI_PUSHED" },
+	{ NPCAI_NO_COLL_AVOID,      "- NPCAI_NO_COLL_AVOID" },
+	{ NPCAI_BLOCKED,            "- NPCAI_BLOCKED" },
+	{ NPCAI_OFF_PATH,           "- NPCAI_OFF_PATH" },
+	{ NPCAI_IN_SQUADPOINT,      "- NPCAI_IN_SQUADPOINT" },
+	{ NPCAI_STRAIGHT_TO_DESTPOS,"- NPCAI_STRAIGHT_TO_DESTPOS" },
+	{ NPCAI_NO_SLOWDOWN,        "- NPCAI_NO_SLOWDOWN" },
+	{ NPCAI_LOST,               "- NPCAI_LOST" },
+	{ NPCAI_SHIELDS,            "- NPCAI_SHIELDS" },
+	{ NPCAI_GREET_ALLIES,       "- NPCAI_GREET_ALLIES" },
+	{ NPCAI_FORM_TELE_NAV,      "- NPCAI_FORM_TELE_NAV" },
+	{ NPCAI_ENROUTE_TO_HOMEWP,  "- NPCAI_ENROUTE_TO_HOMEWP" },
+	{ NPCAI_MATCHPLAYERWEAPON,  "- NPCAI_MATCHPLAYERWEAPON" },
+	{ NPCAI_DIE_ON_IMPACT,      "- NPCAI_DIE_ON_IMPACT" },
+};
+// Function
+static float CG_DrawNPCInfo(float x, float y)
+{
+	gentity_t* NPCPointer = GetLastCrosshairNPC();
+
+	if (NPCPointer)
+	{
+		///// Name/Type /////
+		if (NPCPointer->NPC_type)
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, NPCPointer->NPC_type, colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
+		}
+		///// Name/Type /////
+
+		///// Behaviors /////
+		const char* behaviorDefaultWord = NPCBehaviorName(NPCPointer->NPC->defaultBehavior);
+		if (behaviorDefaultWord)
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, behaviorDefaultWord, colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		}
+		const char* behaviorCurrentWord = NPCBehaviorName(NPCPointer->NPC->behaviorState);
+		if (behaviorCurrentWord)
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, behaviorCurrentWord, colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		}
+		const char* behaviorTempWord = NPCBehaviorName(NPCPointer->NPC->tempBehavior);
+		if (behaviorTempWord)
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, behaviorTempWord, colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		}
+		///// Behaviors /////
+
+		///// Squad /////
+		const char* squadWord = NPCSquadName(NPCPointer->NPC->squadState);
+		if (squadWord && squadWord[0])
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, squadWord, colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+		}
+		///// Squad /////
+
+		///// AI FLAG /////
+		std::string aiFlagWord;
+		int ybuffer = 0;
+		for (AIFlagPair pair : aiFlags)
+		{
+			if (NPCPointer->NPC->aiFlags & pair.flag)
+			{
+				if (!aiFlagWord.empty()) aiFlagWord.push_back('\n'); // Don't want an extra \n at the start
+				aiFlagWord.append(pair.name);
+				ybuffer += BIGCHAR_HEIGHT;
+			}
+		}
+		if (!aiFlagWord.empty())
+		{
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y + 2, aiFlagWord.c_str(), colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
+			y += ybuffer;
+		}
+		///// AI FLAG /////
+
+		return y + BIGCHAR_HEIGHT;
+	}
+	else
+	{
+		return y;
+	}
+}
+
 
 
 /*
@@ -3874,7 +4069,7 @@ static void CG_Draw2DScreenTints( void )
 +CG_DrawOverbounceInfo
 +======================
 +*/
-static void CG_DrawOverbounceInfo( void ) {
+static float CG_DrawOverbounceInfo(float x, float y) {
 	gentity_t const *const player_gent = cg_entities[cg.snap->ps.clientNum].gent;
 
 	vec3_t start;
@@ -3885,7 +4080,7 @@ static void CG_DrawOverbounceInfo( void ) {
 	VectorMA( start, TRACE_LENGTH, cg.refdef.viewaxis[0], end );
 	CG_Trace( &trace, start, vec3_origin, vec3_origin, end, cg.snap->ps.clientNum, MASK_PLAYERSOLID );
 	if ( trace.plane.normal[2] < MIN_WALK_NORMAL ) {
-		return;
+		return y; // No change, return same y
 	}
 
 	double const surfaceClipEpsilon = 0.125;
@@ -3902,25 +4097,33 @@ static void CG_DrawOverbounceInfo( void ) {
 	double const height_difference =
 		cg.snap->ps.origin[2] + player_gent->mins[2] - (trace.endpos[2] - surfaceClipEpsilon);
 	if ( height_difference <= surfaceClipEpsilon * 1.03125 ) {
-		return;
+		return y; // No change, return same y
 	}
+
+	const std::string overbounceWord = "OB Info";
+	y = y + BIGCHAR_HEIGHT;
+	cgi_R_Font_DrawString(x, y, overbounceWord.c_str(), colorTable[CT_GREEN], cgs.media.qhFontMedium, -1, 0.7f);
 
 	double const go_overbounce_probability = cgi_OverbounceProbability(
 		height_difference, cg.snap->ps.velocity[2], cg.snap->ps.gravity);
 	double const go_overbounce_percentage = std::round( go_overbounce_probability * 100.0 );
 	if ( go_overbounce_probability > 0.0 ) {
-		cgi_R_Font_DrawString( 10, 235, va( "G: %.0f%%", go_overbounce_percentage ),
-			colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 1.0f );
+		y = y + BIGCHAR_HEIGHT;
+		cgi_R_Font_DrawString(x, y, va("G: %.0f%%", go_overbounce_percentage),
+			colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
 	}
 	if ( cg.snap->ps.velocity[2] == 0.0 ) {
 		double const jump_overbounce_probability = cgi_OverbounceProbability(
 			height_difference, JUMP_VELOCITY, cg.snap->ps.gravity);
 		double const jump_overbounce_percentage = std::round( jump_overbounce_probability * 100.0 );
 		if ( jump_overbounce_probability > 0.0 ) {
-			cgi_R_Font_DrawString( 10, 255, va( "J: %.0f%%", jump_overbounce_percentage ),
-				colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 1.0f );
+			y = y + BIGCHAR_HEIGHT;
+			cgi_R_Font_DrawString(x, y, va("J: %.0f%%", jump_overbounce_percentage),
+				colorTable[CT_LTGOLD1], cgs.media.qhFontMedium, -1, 0.7f);
 		}
 	}
+
+	return y + BIGCHAR_HEIGHT;
 }
 
 /*
@@ -4314,48 +4517,54 @@ static void CG_Draw2D( void )
 #ifdef _XBOX
 	float y = 32;
 #else
-	float y = 0;
+	float y_right = 0;
 #endif
+	// Right side of the UI used by SpeedAcademy
 	if (g_cheats->integer) {
-		y=CG_DrawCheatsNotice(y);
+		y_right = CG_DrawCheatsNotice(y_right);
 	}
 	if (cg_drawSecrets.integer) {
-		y=CG_DrawSecrets(y);
+		y_right = CG_DrawSecrets(y_right);
 	}
 	if (cg_drawSnapshot.integer) {
-		y=CG_DrawSnapshot(y);
+		y_right = CG_DrawSnapshot(y_right);
 	} 
 	if (cg_drawFPS.integer) {
-		y=CG_DrawFPS(y);
+		y_right = CG_DrawFPS(y_right);
 	} 
 	if (cg_drawTimer.integer) {
-		y=CG_DrawFormattedMilliseconds(cg.time, 0, y);
+		y_right = CG_DrawFormattedMilliseconds(cg.time, 0, y_right);
 	}
 	if (cg_drawSpeedrunTotalTimer.integer > 0) {
-		y=CG_DrawFormattedMilliseconds(cgi_SpeedrunGetTotalTimeMilliseconds(),
-			cg_drawSpeedrunTotalTimer.integer - 1, y);
+		y_right = CG_DrawFormattedMilliseconds(cgi_SpeedrunGetTotalTimeMilliseconds(),
+			cg_drawSpeedrunTotalTimer.integer - 1, y_right);
 	}
 	if (cg_drawSpeedrunLevelTimer.integer > 0) {
-		y=CG_DrawFormattedMilliseconds(cgi_SpeedrunGetLevelTimeMilliseconds(),
-			cg_drawSpeedrunLevelTimer.integer - 1, y);
+		y_right = CG_DrawFormattedMilliseconds(cgi_SpeedrunGetLevelTimeMilliseconds(),
+			cg_drawSpeedrunLevelTimer.integer - 1, y_right);
 	}
 	if (cg_drawMovementRestriction.integer) {
-		y=CG_DrawMovementRestriction(y);
+		y_right = CG_DrawMovementRestriction(y_right);
 	}
+	
 
 	// don't draw center string if scoreboard is up
 	if ( !CG_DrawScoreboard() ) {
 		CG_DrawCenterString();
 	}
 	
-	if ( cg_drawOverbounceInfo.integer )
-	{
-		CG_DrawOverbounceInfo();
-	}
-
-	// Left side of the screen
+	// Left side of the UI used by SpeedAcademy
+	float y_left = 16; // Offset of 16 to see the console
+	const int x_offset = 8; // Little offset to not be all the way on the left (looks better) 
 	if (cg_drawPlayerInfo.integer) {
-		CG_DrawPlayerInfo(cg_drawPlayerInfoPrecision.integer);
+		y_left = CG_DrawPlayerInfo(x_offset, y_left, cg_drawPlayerInfoPrecision.integer);
+	}
+	if (cg_drawNPCInfo.integer) {
+		y_left = CG_DrawNPCInfo(x_offset, y_left);
+	}
+	if (cg_drawOverbounceInfo.integer)
+	{
+		y_left = CG_DrawOverbounceInfo(x_offset, y_left);
 	}
 
 /*	if (cg.showInformation)

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -734,6 +734,7 @@ extern	vmCvar_t		cg_drawBoxPlayer;
 extern	vmCvar_t		cg_drawBoxPlayerFP;
 extern	vmCvar_t		cg_drawBoxNPC;
 extern	vmCvar_t		cg_drawBoxItems;
+extern	vmCvar_t		cg_drawNPCInfo;
 extern	vmCvar_t		cg_drawPlayerInfo;
 extern	vmCvar_t		cg_drawPlayerInfoPrecision;
 

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -422,6 +422,7 @@ vmCvar_t	cg_drawBoxPlayer;
 vmCvar_t	cg_drawBoxPlayerFP;
 vmCvar_t	cg_drawBoxNPC;
 vmCvar_t	cg_drawBoxItems;
+vmCvar_t	cg_drawNPCInfo;
 vmCvar_t	cg_drawPlayerInfo;
 vmCvar_t	cg_drawPlayerInfoPrecision;
 
@@ -658,6 +659,7 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_drawBoxPlayerFP, "cg_drawBoxPlayerFP", "0", CVAR_ARCHIVE },
 	{ &cg_drawBoxNPC, "cg_drawBoxNPC", "0", CVAR_ARCHIVE },
 	{ &cg_drawBoxItems, "cg_drawBoxItems", "0", CVAR_ARCHIVE },
+	{ &cg_drawNPCInfo, "cg_drawNPCInfo", "0", CVAR_ARCHIVE },
 	{ &cg_drawPlayerInfo, "cg_drawPlayerInfo", "0", CVAR_ARCHIVE },
 	{ &cg_drawPlayerInfoPrecision, "cg_drawPlayerInfoPrecision", "2", CVAR_ARCHIVE },
 };

--- a/docs/console_additions.md
+++ b/docs/console_additions.md
@@ -48,6 +48,12 @@ Variables:
   Show a tracker for found versus total number of secrets on the current level.
   Default `0`.
 
+- `cg_drawNPCInfo` : 0 or 1
+
+  Display information about some flags about NPCs such as their default and current behavior.
+  This is triggered when looking at an NPC entity.
+  The last NPC entity will be remembered as long as the player's crosshair doesn't look at any other NPC entity.
+
 ## Landing Info
 
 Variables:
@@ -123,20 +129,24 @@ Commands:
 
 Variables:
 
-- `cg_drawPlayerInfo` (0 to 7)
+- `cg_drawPlayerInfo` (0 to 15)
 
-  Draw information about the player in the current 3D environment.
-  The types of information are the player's position, velocity, and jumping state.
-  Depending on the value of this variable, different information is shown:
+  The displayed result will always be in the following order from top to bottom : Position - Velocity - Angles - Jumping state.
+  
+  #------------------------------------#
+  Binary :      (1    1    1    1) = 15
+  Power of 2^n : 3    2    1    0
+  Decimal :      8    4    2    1
+                 |    |    |    |
+                 |    |    |    Position
+                 |    |    Velocity
+                 |    Angles
+                 Jumping state
+  #------------------------------------#
 
-  - `0` : Nothing
-  - `1` : Position
-  - `2` : Velocity
-  - `3` : Position + Velocity
-  - `4` : Jumping
-  - `5` : Position + Jumping
-  - `6` : Velocity + Jumping
-  - `7` : Position + Velocity + Jumping
+  Examples : 
+  . To enable everything, you must then set the variable to 15 (8 + 4 + 2 + 1)
+  . To only enable velocity and angles, you would set the variable to 6 (4 + 2)
 
   Default: `0`.
 


### PR DESCRIPTION
- Separated the 'left side' and the 'right side' of the UI we draw information on.
- Added a way to draw some NPC variable about their behavior and AI
- Reworked the way to check NPC variables using string arrays.
- Added 'Angles' as a category in CG_DrawPlayerInfo
- Added eyePoints as information in the 'Position' category, used in vertical cam glitch. (Also horizontal cam glitch hunting)
- Added documentation about the new variables.
This commit include the small fix of commit 0405f87 in SpeedOutcast. (Removed magic numbers).