### PR TITLE
cg_draw_speedrun_extras additions

### DIFF
--- a/code/cgame/cg_draw_speedrun_extras.cpp
+++ b/code/cgame/cg_draw_speedrun_extras.cpp
@@ -57,12 +57,103 @@ static void drawBoundingBox(const gentity_t* ent, const byte color[4])
 	}
 }
 
+static void drawLine(vec3_t p1, vec3_t p2, byte color[4], float width, bool onFirstHit)
+{
+	trace_t trace;
+
+	// Copied from CG_ScanForCrosshairEntity
+	memset(&trace, 0, sizeof(trace));
+	if (onFirstHit)
+	{
+		gi.trace(&trace, p1, vec3_origin, vec3_origin, p2,
+			1, MASK_OPAQUE | CONTENTS_SHOTCLIP | CONTENTS_BODY | CONTENTS_ITEM | CONTENTS_TERRAIN, G2_NOCOLLIDE, 10);
+		VectorCopy(trace.endpos, p2);
+	}
+
+	refEntity_t re{};
+	re.reType = RT_LINE;
+	re.radius = width;
+	re.customShader = cgi_R_RegisterShader("gfx/misc/whiteline2");
+	for (int i = 0; i < 4; ++i) { re.shaderRGBA[i] = color[i]; }
+	VectorCopy(p1, re.origin);
+	VectorCopy(p2, re.oldorigin);
+	cgi_R_AddRefEntityToScene(&re);
+}
+
+// Draws a cube given it's center. Mostly copied from drawBoundingBox
+static void drawPositionMarker(vec3_t center, byte color[4], float width, float deltaZ)
+{
+	refEntity_t re{};
+	re.reType = RT_SPRITE;
+	re.radius = width;
+	re.customShader = cgi_R_RegisterShader("gfx/misc/nav_node");
+	for (int i = 0; i < 4; ++i) { re.shaderRGBA[i] = color[i]; }
+	VectorCopy(center, re.origin);
+	re.origin[2] += deltaZ;
+	cgi_R_AddRefEntityToScene(&re);
+}
+
+static void drawLineOfSight(const gentity_t* ent, float width)
+{
+	byte color[4] = { 0, 0, 150, 255 };
+	vec3_t p1, p2;
+	vec3_t d_f, d_rt, d_up;
+
+	// Set the first point to be where the entity is looking at (eye) and the end where it's looking at (direction_forward)
+	VectorCopy(ent->client->renderInfo.eyePoint, p1);
+	AngleVectors(ent->currentAngles, d_f, d_rt, d_up);
+	// Copied from CG_ScanForCrosshairEntity
+	VectorMA(p1, 4096, d_f, p2);
+
+	drawLine(p1, p2, color, width, true);
+}
+
+static void drawVelocityVector(const gentity_t* ent, float width)
+{
+	byte color[4] = { 100, 100, 100, 255 };
+	vec3_t p1, p2;
+
+	VectorCopy(ent->client->ps.origin, p1);
+	p1[2] += 10; // Add an offset so that we can see the start of line around the waist instead of the feets
+
+	// Length in 3D is velovity divided by 10
+	VectorMA(p1, 1.0 / 10.0, ent->client->ps.velocity, p2);
+	p2[2] = p1[2]; // We don't care about the Z component (?)
+
+	// TODO for next time : make it longer but curved, to also add a prediction instead of only the direction.
+
+	drawLine(p1, p2, color, width, true);
+}
+
+static void drawNPCPathing(gentity_t* self)
+{
+	vec3_t centerNPC = { 0, 0, 0 };
+	vec3_t centerGoal = { 0, 0, 0 };
+	byte colorGoal[4] = { 150, 100, 0, 255 };
+
+	// If the NPC has a goalEntity (points in the world called 'waypoints'), they will try to get to it.
+	// For robots, the goalEntity is often Kyle, meaning that they will try to get straight to him.
+	if (self->NPC && self->NPC->goalEntity)
+	{
+		VectorAdd(self->absmin, self->absmax, centerNPC);
+		centerNPC[2] -= 20; // To start a little big lower
+		VectorScale(centerNPC, 0.5, centerNPC);
+		VectorAdd(self->NPC->goalEntity->absmin, self->NPC->goalEntity->absmax, centerGoal);
+		VectorScale(centerGoal, 0.5, centerGoal);
+
+		drawLine(centerNPC, centerGoal, colorGoal, 4, false);
+		drawPositionMarker(centerGoal, colorGoal, 10, 0);
+	}
+}
+
 static void setColorForTrigger(gentity_t* self, byte color[4])
 {
 	gentity_t* subTrigger = NULL;
+	byte red[4]{ 50, 0, 0, 25 };
 
 	//while ((subTrigger = G_Find(subTrigger, FOFS(targetname), self->target)) != NULL)
 	if ((subTrigger = G_Find(subTrigger, FOFS(targetname), self->target)) != NULL)
+	// subtrigger has the u_useFunc but it's 'self' possess the e_TouchFunc defined to know if it's disabled
 	{
 		switch (subTrigger->e_UseFunc)
 		{
@@ -70,17 +161,41 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 		case(useF_NPC_Spawn):
 		case(useF_item_spawn_use):
 		case(useF_NPC_VehicleSpawnUse):
-			color[0] = 100;
-			color[1] = 50;
-			color[2] = 0;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_spawner))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 200;
+					color[1] = 100;
+					color[2] = 0;
+				}
+			}
 			break;
 		// CASE : world/save/map related, in pink.
 		case(useF_target_autosave_use):
 		case(useF_target_level_change_use):
 		case(useF_target_secret_use):
-			color[0] = 100;
-			color[1] = 0;
-			color[2] = 50;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_world))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 100;
+					color[1] = 0;
+					color[2] = 150;
+				}
+			}
 			break;
 		// CASE : interactible elements, in green.
 		case(useF_security_panel_use):
@@ -115,9 +230,21 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 		case(useF_pas_use):
 		case(useF_misc_weapon_shooter_use):
 		case(useF_eweb_use):
-			color[0] = 0;
-			color[1] = 100;
-			color[2] = 0;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_usable))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 0;
+					color[1] = 100;
+					color[2] = 0;
+				}
+			}
 			break;
 		// CASE : 'scripts' / 'func', in greenish cyan.
 		case(useF_Use_Multi):
@@ -129,9 +256,21 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 		case(useF_func_rotating_use):
 		case(useF_funcGlassUse):
 		case(useF_func_timer_use):
-			color[0] = 0;
-			color[1] = 100;
-			color[2] = 50;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_func))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 0;
+					color[1] = 100;
+					color[2] = 50;
+				}
+			}
 			break;
 		// CASE : 'target' ??????, in purple. Note : not found anything is purple during tests
 		case(useF_Use_Target_Give):
@@ -149,18 +288,42 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 		case(useF_target_friction_change_use):
 		case(useF_target_teleporter_use):
 		case(useF_Use_target_push):
-			color[0] = 100;
-			color[1] = 0;
-			color[2] = 100;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_target))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 100;
+					color[1] = 0;
+					color[2] = 50;
+				}
+			}
 			break;
 		// CASE : effects fx & sound, in yellow
 		case(useF_fx_runner_use):
 		case(useF_fx_explosion_trail_use):
 		case(useF_fx_target_beam_use):
 		case(useF_target_play_music_use):
-			color[0] = 100;
-			color[1] = 66;
-			color[2] = 0;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_soundsfx))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 100;
+					color[1] = 50;
+					color[2] = 0;
+				}
+			}
 			break;
 		// CASE : unknown cases, let it be white
 		case(useF_GoExplodeDeath):
@@ -176,91 +339,215 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 		case(useF_misc_replicator_item_remove):
 		case(useF_misc_trip_mine_activate):
 		default:
-			color[0] = 20;
-			color[1] = 20;
-			color[2] = 20;
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_uncategorized))
+			{
+				if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 20;
+					color[1] = 20;
+					color[2] = 20;
+				}
+				else if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+			}
 			break;
 		}
 		color[3] = 128;
 	}
-}
-
-static void drawBoxPlayer(gentity_t* self)
-{
-	// Make it red and semi-transparent
-	byte color[4];
-	color[0] = 50;
-	color[1] = 0;
-	color[2] = 0;
-	color[3] = 25;
-
-	drawBoundingBox(self, color);
-}
-
-static void drawBoxNPC(gentity_t* self)
-{
-	// Make it green and semi-transparent
-	byte color[4];
-	color[0] = 0;
-	color[1] = 50;
-	color[2] = 0;
-	color[3] = 25;
-
-	drawBoundingBox(self, color);
-}
-
-static void drawBoxItems(gentity_t* self)
-{
-	// Make it blue and semi-transparent
-	byte color[4];
-	color[0] = 0;
-	color[1] = 0;
-	color[2] = 50;
-	color[3] = 25;
-
-	drawBoundingBox(self, color);
-}
-
-static void drawBoxWorldTriggers(gentity_t* self)
-{
-	// Default color: blue
-	byte color[4];
-	color[0] = 0;
-	color[1] = 0;
-	color[2] = 100;
-	color[3] = 25;
-
-	// Override for some trigger in other color (ex : secrets)
-	// Do not use blue nor red to know we correctly override the previous color.
-	setColorForTrigger(self, color);
-
-	// At the end, if the trigger has been used, display it in red
-	if (self->e_TouchFunc == touchF_NULL)
+	else
 	{
-		// Red for deactivated triggers
+		// Example : Fuel codes in ns_starpad don't return anything via G_Find.
+		// Don't need to implement any other case afaik, but the structure is ready in case another special case is found.
+		switch (self->e_UseFunc)
+		{
+		case(useF_Use_Multi):
+		case(useF_func_usable_use):
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_func))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 0;
+					color[1] = 100;
+					color[2] = 50;
+				}
+			}
+			break;
+		default:
+			if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+			{
+				color[0] = red[0];
+				color[1] = red[1];
+				color[2] = red[2];
+			}
+			break;
+		}
+	}
+
+	// Specific case for Academy "models/map_objects/imperial/switch.md3" on some maps. They don't have e_TouchFunc defined .
+	//model "models/map_objects/imperial/switch.md3"
+	//classname "misc_model_breakable"
+	//useF_misc_model_use
+	if (self->e_UseFunc == useF_misc_model_use && self->e_TouchFunc == touchF_NULL)
+	{
+		if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_usable))
+		{
+			// Same as buttons
+			color[0] = 0;
+			color[1] = 100;
+			color[2] = 0;
+		}
+	}
+
+	// trigger_doors don't have a e_UseFunc defined, so we check them here with their e_TouchFunc
+	// These are always valid and don't need the disabled filter
+	if (self->e_TouchFunc == touchF_Touch_DoorTrigger)
+	{
+		if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_doors))
+		{
+			// Yellow for doors
+			color[0] = 100;
+			color[1] = 100;
+			color[2] = 0;
+		}
+	}
+
+	// trigger_hurt don't have a e_UseFunc defined, so we check them here with their e_TouchFunc
+	// These are always valid and don't need the disabled filter
+	if (self->e_TouchFunc == touchF_hurt_touch)
+	{
+		if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_hurt))
+		{
+			// Red for death triggers
+			color[0] = 200;
+			color[1] = 0;
+			color[2] = 0;
+			color[3] = 255;
+		}
+	}
+
+}
+
+static void drawPlayerRelated(gentity_t* self)
+{
+	// Step 2 : Check what is enabled as to not show everything
+	if (cg_drawBoxPlayer.integer && cg.renderingThirdPerson) // Don't want a red filter in first person
+	{
+		// Make it red and semi-transparent
+		byte color[4];
 		color[0] = 50;
 		color[1] = 0;
 		color[2] = 0;
 		color[3] = 25;
-	}
 
-	drawBoundingBox(self, color);
+		drawBoundingBox(self, color);
+	}
+	if (cg_drawVelocityVector.integer)
+	{
+		// Draw velocity vector, its 3d length will be it's vec3 values / 10 ; so a speed of 300 will display a line of 30 units in game
+		drawVelocityVector(self, 4);
+	}
+}
+
+static void drawNPCRelated(gentity_t* self)
+{
+	// Step 2 : Check what is enabled as to not show everything
+	if (cg_drawBoxNPC.integer)
+	{
+		// Make it green and semi-transparent
+		byte color[4];
+		color[0] = 0;
+		color[1] = 50;
+		color[2] = 0;
+		color[3] = 25;
+
+		drawBoundingBox(self, color);
+	}
+	if (cg_drawLineOfSight.integer)
+	{
+		// Width of 4, can be adjusted later of needs be
+		drawLineOfSight(self, 4);
+	}
+	if (cg_drawNPCPath.integer)
+	{
+		drawNPCPathing(self);
+	}
+}
+
+static void drawItemRelated(gentity_t* self)
+{
+	if (cg_drawBoxItems.integer)
+	{
+		// Make it blue and semi-transparent
+		byte color[4];
+		color[0] = 0;
+		color[1] = 0;
+		color[2] = 50;
+		color[3] = 25;
+
+		drawBoundingBox(self, color);
+	}
+}
+
+static void drawBoxWorldTriggers(gentity_t* self)
+{
+	// Step 2 : Check what is enabled as to not show everything
+	if (cg_drawBoxTriggers.integer)
+	{
+		// Default color: blue
+		byte color[4];
+		color[0] = 0;
+		color[1] = 0;
+		color[2] = 100;
+		color[3] = 25;
+
+		// Override for some trigger in other color (ex : secrets)
+		// Do not use blue nor red to know we correctly override the previous color.
+		setColorForTrigger(self, color);
+
+		// Default color = no overload by setColorForTrigger because of filtering : return early
+		if (color[0] == 0 && color[1] == 0 && color[2] == 100)
+		{
+			return;
+		}
+
+		drawBoundingBox(self, color);
+	}
 }
 
 static void drawBoxObjectTriggers(gentity_t* self)
 {
-	// Default color: blue
-	byte color[4];
-	color[0] = 0;
-	color[1] = 0;
-	color[2] = 100;
-	color[3] = 25;
+	// Step 2 : Check what is enabled as to not show everything
+	if (cg_drawBoxTriggers.integer)
+	{
+		// Default color: red / same as disabled
+		byte color[4];
+		color[0] = 50;
+		color[1] = 0;
+		color[2] = 0;
+		color[3] = 25;
 
-	// Change in other color (ex : secrets). The first secret in t1_fatal is obtained by destroying a 3D object, it will be colored in pink.
-	// Do not use blue nor red to know we correctly override the previous color.
-	setColorForTrigger(self, color);
+		// Change in other color (ex : secrets). The first secret in t1_fatal is obtained by destroying a 3D object, it will be colored in pink.
+		// Do not use blue nor red to know we correctly override the previous color.
+		setColorForTrigger(self, color);
 
-	drawBoundingBox(self, color);
+		// Default color = no trigger found for this object : don't render the box
+		if (color[0] == 50 && color[1] == 0 && color[2] == 0)
+		{
+			return;
+		}
+
+		drawBoundingBox(self, color);
+	}
 }
 
 void CG_DrawSpeedrunExtras()
@@ -298,46 +585,36 @@ void CG_DrawSpeedrunExtras()
 	///// Trigger related boxes /////
 
 
-	// Player
-	if (cg_drawBoxPlayer.integer && (cg.renderingThirdPerson || (!cg.renderingThirdPerson && cg_drawBoxPlayerFP.integer)))
-	{
-		// Player is always the first on this array
-		drawBoxPlayer(&g_entities[0]);
-	}
+	// Player related stuff can be done indepedent from the loop so no needs for an early return
+	drawPlayerRelated(&g_entities[0]);
 
-	if (!cg_drawBoxNPC.integer && !cg_drawBoxItems.integer && !cg_drawBoxTriggers.integer) {
-		// no need to do the loop if nonce of these is enabled
+	// Step 0 : big check of every variable, don't if none of them are enabled
+	if (!cg_drawBoxNPC.integer && !cg_drawBoxItems.integer && !cg_drawBoxTriggers.integer
+		&& !cg_drawLineOfSight.integer && !cg_drawNPCPath.integer)
+	{
 		return;
 	}
 
+	// Step 1 : loop all g_entities and give the pointer to the corresponding function.
 	for (int i = 0; i < MAX_GENTITIES; ++i)
 	{
-		// NPCs
-		if (cg_drawBoxNPC.integer && g_entities[i].e_ThinkFunc == thinkF_NPC_Think)
+		if (g_entities[i].e_ThinkFunc == thinkF_NPC_Think)
 		{
-			drawBoxNPC(&g_entities[i]);
+			drawNPCRelated(&g_entities[i]);
 		}
-
-		// Items
-		if (cg_drawBoxItems.integer && g_entities[i].e_TouchFunc == touchF_Touch_Item)
+		if (g_entities[i].e_TouchFunc == touchF_Touch_Item)
 		{
-			drawBoxItems(&g_entities[i]);
+			drawItemRelated(&g_entities[i]);
 		}
-
-		// Triggers, but related to the world (not associated with an ingame object like a button or a camera)
-		if (cg_drawBoxTriggers.integer && g_entities[i].classname &&
-		    ( strcmp( g_entities[i].classname, "trigger_multiple" ) == 0  ||
-		      strcmp( g_entities[i].classname, "trigger_once" ) == 0 ))
+		// Different logic for objects and world trigger, so keep both functions separated.
+		if (g_entities[i].classname &&
+			(strncmp(g_entities[i].classname, "trigger_", strlen("trigger_")) == 0))
 		{
 			drawBoxWorldTriggers(&g_entities[i]);
 		}
-
-		// Triggers, but related to	an object like a button or a camera
-		if (cg_drawBoxTriggers.integer && g_entities[i].classname &&
-		    ( strncmp(g_entities[i].classname, "func_", strlen("func_")) == 0 ||
-		      strncmp(g_entities[i].classname, "misc_", strlen("misc_")) == 0)
-			// bigbomb | t2_wedge
-			)
+		if (g_entities[i].classname &&
+			(strncmp(g_entities[i].classname, "func_", strlen("func_")) == 0 ||
+				(strncmp(g_entities[i].classname, "misc_", strlen("misc_")) == 0)))
 		{
 			drawBoxObjectTriggers(&g_entities[i]);
 		}

--- a/code/cgame/cg_draw_speedrun_extras.cpp
+++ b/code/cgame/cg_draw_speedrun_extras.cpp
@@ -360,12 +360,11 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 	}
 	else
 	{
-		// Example : Fuel codes in ns_starpad don't return anything via G_Find.
-		// Don't need to implement any other case afaik, but the structure is ready in case another special case is found.
+		// Example : some triggers aren't found by G_Find but are instead linked directly to the 'self' entity.
 		switch (self->e_UseFunc)
 		{
 		case(useF_Use_Multi):
-		case(useF_func_usable_use):
+		case(useF_func_usable_use): // Useless but there are some entities hitting this check, leave it present ?
 			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_func))
 			{
 				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
@@ -382,6 +381,42 @@ static void setColorForTrigger(gentity_t* self, byte color[4])
 				}
 			}
 			break;
+		case(useF_funcBBrushUse): // Push to destroy wall brush (yavin2)
+			if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_usable))
+			{
+				if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+				{
+					color[0] = red[0];
+					color[1] = red[1];
+					color[2] = red[2];
+				}
+				else if (self->e_TouchFunc != touchF_NULL)
+				{
+					color[0] = 0;
+					color[1] = 100;
+					color[2] = 0;
+				}
+			}
+			break;
+		case(useF_Use_BinaryMover): // Push/Pull walls (yavin2)
+			if (self->spawnflags & 1 || self->spawnflags & 2) // Same check as in cg_draw CG_ScanForCrosshairEntity
+			{
+				if (!cg_drawBoxTriggersFilter.integer || (cg_drawBoxTriggersFilter.integer & trig_filter_uncategorized))
+				{
+					if (self->e_TouchFunc != touchF_NULL)
+					{
+						color[0] = 20;
+						color[1] = 20;
+						color[2] = 20;
+					}
+					else if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
+					{
+						color[0] = red[0];
+						color[1] = red[1];
+						color[2] = red[2];
+					}
+				}
+			}
 		default:
 			if (self->e_TouchFunc == touchF_NULL && cg_drawBoxTriggersFilterDisabled.integer)
 			{

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -730,14 +730,18 @@ extern	vmCvar_t		cg_yawSpeeder;
 extern	vmCvar_t		cg_yawTauntaun;
 extern	vmCvar_t		cg_yawVehicle;
 extern	vmCvar_t		cg_drawBoxTriggers;
+extern	vmCvar_t		cg_drawBoxTriggersFilter;
+extern	vmCvar_t		cg_drawBoxTriggersFilterDisabled;
 extern	vmCvar_t		cg_drawBoxPlayer;
-extern	vmCvar_t		cg_drawBoxPlayerFP;
 extern	vmCvar_t		cg_drawBoxNPC;
 extern	vmCvar_t		cg_drawBoxItems;
 extern	vmCvar_t		cg_drawNPCInfo;
 extern	vmCvar_t		cg_drawPlayerInfo;
 extern	vmCvar_t		cg_drawPlayerInfoPrecision;
+extern	vmCvar_t		cg_drawLineOfSight;
+extern	vmCvar_t		cg_drawNPCPath;
 extern	vmCvar_t		cg_drawSpeedrunCheckpoint;
+extern	vmCvar_t		cg_drawVelocityVector;
 
 void CG_NewClientinfo( int clientNum );
 //

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -418,14 +418,18 @@ vmCvar_t	cg_yawSpeeder;
 vmCvar_t	cg_yawTauntaun;
 vmCvar_t	cg_yawVehicle;
 vmCvar_t	cg_drawBoxTriggers;
+vmCvar_t	cg_drawBoxTriggersFilter;
+vmCvar_t	cg_drawBoxTriggersFilterDisabled;
 vmCvar_t	cg_drawBoxPlayer;
-vmCvar_t	cg_drawBoxPlayerFP;
 vmCvar_t	cg_drawBoxNPC;
 vmCvar_t	cg_drawBoxItems;
 vmCvar_t	cg_drawNPCInfo;
 vmCvar_t	cg_drawPlayerInfo;
 vmCvar_t	cg_drawPlayerInfoPrecision;
+vmCvar_t	cg_drawLineOfSight;
+vmCvar_t	cg_drawNPCPath;
 vmCvar_t	cg_drawSpeedrunCheckpoint;
+vmCvar_t	cg_drawVelocityVector;
 
 typedef struct {
 	vmCvar_t	*vmCvar;
@@ -656,14 +660,18 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_yawTauntaun, "cg_yawTauntaun", "0.0", CVAR_ARCHIVE },
 	{ &cg_yawVehicle, "cg_yawVehicle", "0.0", CVAR_ARCHIVE },
 	{ &cg_drawBoxTriggers, "cg_drawBoxTriggers", "0", CVAR_ARCHIVE },
+	{ &cg_drawBoxTriggersFilter, "cg_drawBoxTriggersFilter", "0", CVAR_ARCHIVE },
+	{ &cg_drawBoxTriggersFilterDisabled, "cg_drawBoxTriggersFilterDisabled", "1", CVAR_ARCHIVE },
 	{ &cg_drawBoxPlayer, "cg_drawBoxPlayer", "0", CVAR_ARCHIVE },
-	{ &cg_drawBoxPlayerFP, "cg_drawBoxPlayerFP", "0", CVAR_ARCHIVE },
 	{ &cg_drawBoxNPC, "cg_drawBoxNPC", "0", CVAR_ARCHIVE },
 	{ &cg_drawBoxItems, "cg_drawBoxItems", "0", CVAR_ARCHIVE },
 	{ &cg_drawNPCInfo, "cg_drawNPCInfo", "0", CVAR_ARCHIVE },
 	{ &cg_drawPlayerInfo, "cg_drawPlayerInfo", "0", CVAR_ARCHIVE },
 	{ &cg_drawPlayerInfoPrecision, "cg_drawPlayerInfoPrecision", "2", CVAR_ARCHIVE },
+	{ &cg_drawLineOfSight, "cg_drawLineOfSight", "0", CVAR_ARCHIVE },
+	{ &cg_drawNPCPath, "cg_drawNPCPath", "0", CVAR_ARCHIVE },
 	{ &cg_drawSpeedrunCheckpoint, "cg_drawSpeedrunCheckpoint", "0", CVAR_ARCHIVE },
+	{ &cg_drawVelocityVector, "cg_drawVelocityVector", "0", CVAR_ARCHIVE },
 };
 
 static int cvarTableSize = sizeof( cvarTable ) / sizeof( cvarTable[0] );

--- a/docs/console_additions.md
+++ b/docs/console_additions.md
@@ -214,6 +214,12 @@ Variables:
   These are `Accelerating`, `Optimal`, `CenterMarker` and `Speed`.
   Colors can be set more conveniently with the corresponding commands.
 
+- `cg_drawVelocityVector` (0 or 1)
+
+  Draw a 3D rectangle representing the current velocity vector of the player when moving in the world.
+  It's 3D length is 1/10 of the units values stored internally.
+  Example : a forward volocity of 250 (walking) will result in a rectangle of length 25 ingame units in the direction the player is walking to.
+
 Commands:
 
 - `strafeHelperColor[...] <r> <g> <b> <a>` (components in range 0.0 to 1.0)
@@ -311,25 +317,82 @@ Variables:
 
 - `cg_drawBoxTriggers` : 0 or 1
 
-  Draw in different colors (ex : pink or orange for secrets) triggers around the map.
-  By default, triggers will be drawn white when there is no color defined.
+  Render game triggers in the world with different colors depending on their type.
+  Color code : 
+  - Green : interactibles. Example : cairn_assembly cameras or buttons in kejim_post.
+  - Orange : spawners (NPCs or items). Example : kejim_post, after the window jump.
+  - Yellow : doors triggers. Example : everywhere.
+  - Purple : secrets zone, checkpoints saves, mission update and level change.
+  - Pink and blue : any kind of scripts. Example : doors in ns_streets when interacted with, will make a sound.
+  - Red : disabled trigger. Example : after triggering the NPC spawn on kejim_post.
+  - White : uncategorized. Example : the one runner are trying to access in artus_detention, making the door near the end level openable.
+
+  Default: `0`.
+
+- `cg_drawBoxTriggersFilter` : 0 to 511
+  
+  #------------------------------------------------------------------------------------------------#
+  Binary :      (1    1    1    1    1    1    1    1    1    1) = 1023
+  Power of 2^n : 9    8    7    6    5    4    3    2    1    0
+  Decimal :      512  256  128  64   32   16   8    4    2    1
+                 |    |    |    |    |    |    |    |    |    |
+                 |    |    |    |    |    |    |    |    |    Orange : Spawners
+                 |    |    |    |    |    |    |    |    Purple : World+Save
+                 |    |    |    |    |    |    |    Green : Interactibles
+                 |    |    |    |    |    |    Cyan : 'func' Scripts
+                 |    |    |    |    |    Pink : 'target' scripts
+                 |    |    |    |    Pink light : fx & sounds
+                 |    |    |    White : Unknowns
+                 |    |    Yellow : Doors
+                 |    Red opaque : Death & Hurt
+                 Unused (yet?)
+
+
+  #------------------------------------------------------------------------------------------------#
+  
+  Examples : 
+  . To enable everything, set the variable to 511.
+  . To only enable doors (yellow), spawners (orange) and level changes (purple), set the variable to 131 (128 + 2 + 1)
+  . Setting the variable to 0 will disable the filter (and so the bahavior is like 511 where you enable everything).
+
+  Default: `0`.
+
+- `cg_drawBoxTriggersFilterDisabled` : 0 or 1
+
+  Enable or not, the rendering of used/disabled triggers, in light red.
+  Example : after using a spawner (in orange), the trigger is considered 'disbaled' and would still render in red if this variable is set to 1.
+  On the contrary, if this is set to 0, after using the same trigger, the rendering would stop and visually the rectangle would disappear.
+
+  Default: `1`.
 
 - `cg_drawBoxPlayer` : 0 or 1
 
   Draw in RED, the box around the player
-
-- `cg_drawBoxPlayerFP` : 0 or 1
-
-  Allows rendering if the box even in first person if set to 1 or more.
-  Needs `cg_drawBoxPlayer` to also be set to 1
+  Default: `0`.
 
 - `cg_drawBoxNPC` : 0 or 1
 
   Draw in GREEN, the boxes around NPCs (include spawned NPCs)
+  Default: `0`.
 
 - `cg_drawBoxItems` : 0 or 1
 
   Draw in BLUE, the boxes around items (include dropped weapons)
+  Default: `0`.
+
+## Ingame NPC behavior, line of sight and pathing rendering
+
+Variables: 
+
+- `cg_drawLineOfSight` : 0 or 1
+
+  Draw a blue line showing what every NPC is looking at.
+  Will stop at the first collision encountered (includes player)
+
+- `cg_drawNPCPath` : 0 or 1
+
+  Draw in orange, a line showing where an NPC is trying to go to, a 'goal' destination.
+  This does not include the whole path that an NPC will take to get to said goal.
 
 ## Maximum Jump Height Visualization
 


### PR DESCRIPTION
- cg_drawLineOfSight : draw a line between the eye of an NPC entity and the forward direction of where they are looking at. This line will stop at the first collision in the world.
- cg_drawNPCPath : draw a line and a little cube at the end between the current position of an NPC and their destination goal.
- cg_drawVelocityVector : draw a little line representing the current velocity direction of the player, works on 'stucklaunch' on t3_tail.
- Added filters for triggers to only draw what is wanted.
- Changed some colors in setColorForTrigger, same as in Outcast.
- Use only the start of the word "trigger_" as a search terms.
- Added a check in case G_Find don't find a subtrigger.
- Added a special case for Academy's switches (that can still be 'used' even when their one time action is done)