### PR TITLE
Fix miscellaneous not precached assets

### DIFF
--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -957,6 +957,12 @@ static inline void CG_AS_Register(void)
 		cgi_AS_AddPrecacheEntry( ((*pi).first).c_str() );
 	}
 
+	if (_strnicmp(cgs.mapname, "academy", 7) != 0
+		|| strcmp(cgs.mapname, "t1_inter") != 0)
+	{
+		cgi_AS_AddPrecacheEntry("yavin_interior");
+	}
+
 	cgi_AS_ParseSets();
 }
 

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -85,7 +85,7 @@ void CG_RegisterWeapon( int weaponNum ) {
 		{
 			*spot = 0;
 			spot = strstr(weaponModel, "_w");//i'm using the in view weapon array instead of scanning the item list, so put the _w back on
-			if (!spot) 
+			if (!spot&&!strstr(weaponModel, "noweap"))
 			{
 				strcat (weaponModel, "_w");
 			}
@@ -563,6 +563,7 @@ void CG_RegisterWeapon( int weaponNum ) {
 		//not used (eventually)?
 		cgi_R_RegisterShader( "gfx/effects/blueLine" );
 		cgi_R_RegisterShader( "gfx/misc/whiteline2" );
+		cgi_R_RegisterShader( "gfx/effects/smokeTrail" );
 		break;
 
 	case WP_THERMAL:
@@ -666,6 +667,11 @@ void CG_RegisterWeapon( int weaponNum ) {
 		//explosion
 		theFxScheduler.RegisterEffect( "noghri_stick/gas_cloud" );
 		//cgi_S_RegisterSound("sound/weapons/noghri/smoke.wav");
+
+		for (i = 1; i < 5; i ++ )
+		{
+			cgi_S_RegisterSound( va( "sound/weapons/tusken_staff/stickhit%d.wav", i ) );
+		}
 		break;
 
 	case WP_TIE_FIGHTER:

--- a/code/game/NPC_stats.cpp
+++ b/code/game/NPC_stats.cpp
@@ -1369,7 +1369,8 @@ void NPC_PrecacheWeapons( team_t playerTeam, int spawnflags, char *NPCtype )
 			if (char *spot = strstr(weaponModel, ".md3") ) {
 				*spot = 0;
 				spot = strstr(weaponModel, "_w");//i'm using the in view weapon array instead of scanning the item list, so put the _w back on
-				if (!spot) {
+				if (!spot&&!strstr(weaponModel, "noweap"))
+				{
 					strcat (weaponModel, "_w");
 				}
 				strcat (weaponModel, ".glm");	//and change to ghoul2

--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -1938,7 +1938,17 @@ void G_SetSabersFromCVars( gentity_t *ent )
 void G_InitPlayerFromCvars( gentity_t *ent )
 {
 	//set model based on cvars
-	G_ChangePlayerModel( ent, va("%s|%s|%s|%s", g_char_model->string, g_char_skin_head->string, g_char_skin_torso->string, g_char_skin_legs->string) );
+	if (Q_stricmp( "hoth2", level.mapname ) == 0	//hack, is this the only map?
+		||
+		Q_stricmp( "hoth3", level.mapname ) == 0	// no! ;-)
+		)
+	{
+		G_ChangePlayerModel(ent, va("%s|%s|%s|%s", g_char_model->string, g_char_skin_head->string, "torso_g1", "lower_e1"));
+	}
+	else
+	{
+		G_ChangePlayerModel( ent, va("%s|%s|%s|%s", g_char_model->string, g_char_skin_head->string, g_char_skin_torso->string, g_char_skin_legs->string) );
+	}
 
 	//FIXME: parse these 2 from some cvar or require playermodel to be in a *.npc?
 	if( ent->NPC_type && gi.bIsFromZone(ent->NPC_type, TAG_G_ALLOC) ) {

--- a/code/renderer/tr_draw.cpp
+++ b/code/renderer/tr_draw.cpp
@@ -1032,42 +1032,6 @@ qboolean RE_InitDissolve(qboolean bForceCircularExtroWipe)
 			// ... and load appropriate graphics...
 			//
 
-			// special tweak, although this code is normally called just before client spawns into world (and
-			//	is therefore pretty much immune to precache issues) I also need to make sure that the inverse
-			//	iris graphic is loaded so for the special case of doing a circular wipe at the end of the last
-			//	level doesn't stall on loading the image. So I'll load it here anyway - to prime the image - 
-			//	then allow the random wiper to overwrite the ptr if needed. This way the end of level call
-			//	will be instant.  Downside: every level has one extra 256x256 texture.
-#ifndef _XBOX	// Trying to decipher these comments - looks like no problem taking this out. I want the RAM.
-			{
-					Dissolve.pDissolve = R_FindImageFile(	"gfx/2d/iris_mono_rev",		// const char *name
-															qfalse,						// qboolean mipmap
-															qfalse,						// qboolean allowPicmip
-															qfalse,						// qboolean allowTC
-															GL_CLAMP					// int glWrapClampMode 
-														);
-			}
-#endif
-
-			extern cvar_t *com_buildScript;
-			if (com_buildScript->integer)
-			{
-				// register any/all of the possible CASE statements below...
-				//
-				Dissolve.pDissolve = R_FindImageFile(	"gfx/2d/iris_mono",			// const char *name
-														qfalse,						// qboolean mipmap
-														qfalse,						// qboolean allowPicmip
-														qfalse,						// qboolean allowTC
-														GL_CLAMP					// int glWrapClampMode 
-													);
-				Dissolve.pDissolve = R_FindImageFile(	"textures/common/dissolve",	// const char *name
-														qfalse,						// qboolean mipmap
-														qfalse,						// qboolean allowPicmip
-														qfalse,						// qboolean allowTC
-														GL_REPEAT					// int glWrapClampMode 
-													);
-			}
-
 			switch (Dissolve.eDissolveType)
 			{
 				case eDISSOLVE_CIRCULAR_IN:

--- a/code/renderer/tr_model.cpp
+++ b/code/renderer/tr_model.cpp
@@ -396,6 +396,29 @@ int RE_RegisterMedia_GetLevel(void)
 	return giRegisterMedia_CurrentLevel;
 }
 
+static void RE_PrecacheDissolveImages()
+{
+	R_FindImageFile(	"gfx/2d/iris_mono_rev",		// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_CLAMP					// int glWrapClampMode
+										);
+
+	R_FindImageFile(	"gfx/2d/iris_mono",			// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_CLAMP					// int glWrapClampMode
+										);
+	R_FindImageFile(	"textures/common/dissolve",	// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_REPEAT					// int glWrapClampMode
+										);
+}
+
 extern qboolean SND_RegisterAudio_LevelLoadEnd(qboolean bDeleteEverythingNotUsedThisLevel);
 
 void RE_RegisterMedia_LevelLoadEnd(void)
@@ -403,6 +426,12 @@ void RE_RegisterMedia_LevelLoadEnd(void)
 	RE_RegisterModels_LevelLoadEnd(qfalse);
 	RE_RegisterImages_LevelLoadEnd();
 	SND_RegisterAudio_LevelLoadEnd(qfalse);
+
+	// Without this, RE_InitDissolve call from SCR_StopCinematic causes unprecached issue in the following scenarios:
+	// 1. First snapshot RE_InitDissolve loaded different dissolve image (eDissolveType is random);
+	// 2. vid_restart cleared allocated images, if gbAllowScreenDissolve is 0, no dissolved images are precached;
+	// 3. Loaded saved game from other level
+	RE_PrecacheDissolveImages();
 
 	if (gbAllowScreenDissolve)
 	{


### PR DESCRIPTION
# Issues
### Same as JK2
1. noweap.glm not precached on spawning npcs with weapon types using noweap model (taspir2 first jedis spawn).
2. Dissolve images sometimes are not precached on stopping cinematic.
### JKA only
3. yavin_int.wav ambient sound not precached on yavin_inter and academy maps.
4. smokeTrail effect not precached when missing alt shot (`FX_ConcAltMiss`) (t3_byss);
5. Stickhit sound not precached (`Noghri_StickTrace`) (t3_hevil);
6. Skin parts not precached (hoth player skin). Steps to reproduce:  load auto_hoth3; hit spawn trigger before the cutscene with reborn.

# Fixes
1. Add noweap.glm explicit handling (`NPC_PrecacheWeapons`, `CG_RegisterWeapon`);
2. Add dissolve images precaching (`RE_RegisterMedia_LevelLoadEnd`);
3. Add yavin_int.wav ambient sound precaching for t1_inter and academy maps;
4. Add smokeTrail effect precaching for concussion rifle (`CG_RegisterWeapon`);
5. Add tusken staff stickhit sounds precaching for noghri stick (`CG_RegisterWeapon`);
6. Add explicit skin registration for spawning player NPC on hoth2 and hoth3 (`G_InitPlayerFromCvars`).