### PR TITLE
Fix not precached menu assets

### DIFF
--- a/code/ui/ui_atoms.cpp
+++ b/code/ui/ui_atoms.cpp
@@ -140,44 +140,87 @@ char *UI_Cvar_VariableString( const char *var_name )
 UI_Cache
 =================
 */
-static void UI_Cache_f( void ) 
+void UI_Cache_f( void )
 {
  int index;
 	Menu_Cache();
 
-extern const char *lukeForceStatusSounds[];
-extern const char *kyleForceStatusSounds[];
+	int	tier_storyinfo = Cvar_VariableIntegerValue( "tier_storyinfo" );
 
-	for (index = 0; index < 5; index++)
+	if (tier_storyinfo == 4 || tier_storyinfo == 5
+		|| tier_storyinfo == 10 || tier_storyinfo == 11
+		|| tier_storyinfo == 16 || tier_storyinfo == 17)
 	{
-		DC->registerSound(lukeForceStatusSounds[index], qfalse);
-		DC->registerSound(kyleForceStatusSounds[index], qfalse);
+		extern const char *lukeForceStatusSounds[];
+		extern const char *kyleForceStatusSounds[];
+
+		for (index = 0; index < 5; index++)
+		{
+			DC->registerSound(lukeForceStatusSounds[index], qfalse);
+			DC->registerSound(kyleForceStatusSounds[index], qfalse);
+		}
 	}
-	for (index = 1; index <= 18; index++)
+
+	DC->registerSound(va("sound/chars/storyinfo/%d",tier_storyinfo), qfalse);
+
+	trap_S_RegisterSound("sound/weapons/blaster/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/bowcaster/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/disruptor/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/demp2/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/thermal/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/detpack/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/flechette/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/repeater/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/concussion/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/rocket/select.mp3", qfalse);
+
+	if (tier_storyinfo && tier_storyinfo < 7)
 	{
-		DC->registerSound(va("sound/chars/storyinfo/%d",index), qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/04kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/05kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/06luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/07kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/08luk001.mp3", qfalse);
 	}
-	trap_S_RegisterSound("sound/chars/kyle/04kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/05kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/07kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/14kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/21kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/24kyk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/kyle/25kyk001.mp3", qfalse);
 
-	trap_S_RegisterSound("sound/chars/luke/06luk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/luke/08luk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/luke/22luk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/luke/23luk001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/protocol/12pro001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/protocol/15pro001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/protocol/16pro001.mp3", qfalse);
-	trap_S_RegisterSound("sound/chars/wedge/13wea001.mp3", qfalse);
+	if (tier_storyinfo >= 7 && tier_storyinfo < 13)
+	{
+		trap_S_RegisterSound("sound/chars/protocol/12pro001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/wedge/13wea001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/14kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/protocol/15pro001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/protocol/16pro001.mp3", qfalse);
+	}
+
+	if (tier_storyinfo >= 13 && tier_storyinfo < 17)
+	{
+		trap_S_RegisterSound("sound/chars/kyle/21kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/22luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/23luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/24kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/25kyk001.mp3", qfalse);
+	}
+
+	trap_S_RegisterSound("sound/interface/button1.mp3", qfalse);
+
+	// saber menu
+	if (!strcmp(sv_mapname->string, "academy5"))
+	{
+		for (index = 1; index < 10; index++)
+		{
+			RE_RegisterModel(va("models/weapons2/saber_%d/saber_%d.glm", index, index));
+		}
+
+		for (index = 1; index < 6; index++)
+		{
+			RE_RegisterModel(va("models/weapons2/saber_dual_%d/saber_dual_%d.glm", index, index));
+		}
+	}
 
 
-	Menus_ActivateByName("ingameMissionSelect1");
-	Menus_ActivateByName("ingameMissionSelect2");
-	Menus_ActivateByName("ingameMissionSelect3");
+	// Menus_ActivateByName("ingameMissionSelect1");
+	// Menus_ActivateByName("ingameMissionSelect2");
+	// Menus_ActivateByName("ingameMissionSelect3");
 }
 
 

--- a/code/ui/ui_atoms.cpp
+++ b/code/ui/ui_atoms.cpp
@@ -140,87 +140,44 @@ char *UI_Cvar_VariableString( const char *var_name )
 UI_Cache
 =================
 */
-void UI_Cache_f( void )
+static void UI_Cache_f( void ) 
 {
  int index;
 	Menu_Cache();
 
-	int	tier_storyinfo = Cvar_VariableIntegerValue( "tier_storyinfo" );
+extern const char *lukeForceStatusSounds[];
+extern const char *kyleForceStatusSounds[];
 
-	if (tier_storyinfo == 4 || tier_storyinfo == 5
-		|| tier_storyinfo == 10 || tier_storyinfo == 11
-		|| tier_storyinfo == 16 || tier_storyinfo == 17)
+	for (index = 0; index < 5; index++)
 	{
-		extern const char *lukeForceStatusSounds[];
-		extern const char *kyleForceStatusSounds[];
-
-		for (index = 0; index < 5; index++)
-		{
-			DC->registerSound(lukeForceStatusSounds[index], qfalse);
-			DC->registerSound(kyleForceStatusSounds[index], qfalse);
-		}
+		DC->registerSound(lukeForceStatusSounds[index], qfalse);
+		DC->registerSound(kyleForceStatusSounds[index], qfalse);
 	}
-
-	DC->registerSound(va("sound/chars/storyinfo/%d",tier_storyinfo), qfalse);
-
-	trap_S_RegisterSound("sound/weapons/blaster/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/bowcaster/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/disruptor/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/demp2/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/thermal/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/detpack/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/flechette/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/repeater/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/concussion/select.mp3", qfalse);
-	trap_S_RegisterSound("sound/weapons/rocket/select.mp3", qfalse);
-
-	if (tier_storyinfo && tier_storyinfo < 7)
+	for (index = 1; index <= 18; index++)
 	{
-		trap_S_RegisterSound("sound/chars/kyle/04kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/kyle/05kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/luke/06luk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/kyle/07kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/luke/08luk001.mp3", qfalse);
+		DC->registerSound(va("sound/chars/storyinfo/%d",index), qfalse);
 	}
+	trap_S_RegisterSound("sound/chars/kyle/04kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/05kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/07kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/14kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/21kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/24kyk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/kyle/25kyk001.mp3", qfalse);
 
-	if (tier_storyinfo >= 7 && tier_storyinfo < 13)
-	{
-		trap_S_RegisterSound("sound/chars/protocol/12pro001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/wedge/13wea001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/kyle/14kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/protocol/15pro001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/protocol/16pro001.mp3", qfalse);
-	}
-
-	if (tier_storyinfo >= 13 && tier_storyinfo < 17)
-	{
-		trap_S_RegisterSound("sound/chars/kyle/21kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/luke/22luk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/luke/23luk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/kyle/24kyk001.mp3", qfalse);
-		trap_S_RegisterSound("sound/chars/kyle/25kyk001.mp3", qfalse);
-	}
-
-	trap_S_RegisterSound("sound/interface/button1.mp3", qfalse);
-
-	// saber menu
-	if (!strcmp(sv_mapname->string, "academy5"))
-	{
-		for (index = 1; index < 10; index++)
-		{
-			RE_RegisterModel(va("models/weapons2/saber_%d/saber_%d.glm", index, index));
-		}
-
-		for (index = 1; index < 6; index++)
-		{
-			RE_RegisterModel(va("models/weapons2/saber_dual_%d/saber_dual_%d.glm", index, index));
-		}
-	}
+	trap_S_RegisterSound("sound/chars/luke/06luk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/luke/08luk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/luke/22luk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/luke/23luk001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/protocol/12pro001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/protocol/15pro001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/protocol/16pro001.mp3", qfalse);
+	trap_S_RegisterSound("sound/chars/wedge/13wea001.mp3", qfalse);
 
 
-	// Menus_ActivateByName("ingameMissionSelect1");
-	// Menus_ActivateByName("ingameMissionSelect2");
-	// Menus_ActivateByName("ingameMissionSelect3");
+	Menus_ActivateByName("ingameMissionSelect1");
+	Menus_ActivateByName("ingameMissionSelect2");
+	Menus_ActivateByName("ingameMissionSelect3");
 }
 
 

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -2836,6 +2836,8 @@ qboolean Load_Menu(const char **holdBuffer)
 	return qfalse;
 }
 
+extern void UI_Cache_f();
+
 /*
 =================
 UI_LoadMenus
@@ -2845,6 +2847,8 @@ UI_LoadMenus
 void UI_LoadMenus(const char *menuFile, qboolean reset) 
 {
 	SpeedrunPauseTimer(2);
+
+	UI_Cache_f();
 
 //	pc_token_t token;
 //	int handle;

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -2836,8 +2836,6 @@ qboolean Load_Menu(const char **holdBuffer)
 	return qfalse;
 }
 
-extern void UI_Cache_f();
-
 /*
 =================
 UI_LoadMenus
@@ -2847,8 +2845,6 @@ UI_LoadMenus
 void UI_LoadMenus(const char *menuFile, qboolean reset) 
 {
 	SpeedrunPauseTimer(2);
-
-	UI_Cache_f();
 
 //	pc_token_t token;
 //	int handle;
@@ -4167,6 +4163,8 @@ void Menu_Cache( void )
 	// Common menu graphics
 	uis.whiteShader = ui.R_RegisterShader( "white" );
 	uis.menuBackShader = ui.R_RegisterShaderNoMip( "menu/art/unknownmap" );
+
+	trap_S_RegisterSound("sound/interface/button1.mp3", qfalse);
 }
 
 /*

--- a/code/ui/ui_shared.cpp
+++ b/code/ui/ui_shared.cpp
@@ -16,6 +16,8 @@
 #include "ui_shared.h"
 #include "menudef.h"
 
+#include "../speedrun/speedrun_timer_q3/timer.h"
+
 void		UI_LoadMenus(const char *menuFile, qboolean reset);
 
 #ifdef _XBOX
@@ -5305,6 +5307,99 @@ void Menu_SetupKeywordHash(void)
 	}
 }
 
+/*
+===============
+MissionSelectMenu_Cache
+===============
+*/
+void MissionSelectMenu_Cache()
+{
+	int index;
+
+	int	tier_storyinfo = Cvar_VariableIntegerValue( "tier_storyinfo" );
+
+	if (tier_storyinfo == 5 || tier_storyinfo == 6
+		|| tier_storyinfo == 11 || tier_storyinfo == 12
+		|| tier_storyinfo == 17 || tier_storyinfo == 18)
+	{
+		extern const char *lukeForceStatusSounds[];
+		extern const char *kyleForceStatusSounds[];
+
+		for (index = 0; index < 5; index++)
+		{
+			DC->registerSound(lukeForceStatusSounds[index], qfalse);
+			DC->registerSound(kyleForceStatusSounds[index], qfalse);
+		}
+	}
+
+	DC->registerSound(va("sound/chars/storyinfo/%d",tier_storyinfo), qfalse);
+
+
+	if (tier_storyinfo > 0 && tier_storyinfo < 6)
+	{
+		trap_S_RegisterSound("sound/chars/kyle/04kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/05kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/06luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/07kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/08luk001.mp3", qfalse);
+	}
+	else if (tier_storyinfo > 6 && tier_storyinfo < 12)
+	{
+		trap_S_RegisterSound("sound/chars/protocol/12pro001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/wedge/13wea001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/14kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/protocol/15pro001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/protocol/16pro001.mp3", qfalse);
+	}
+	else if (tier_storyinfo > 12 && tier_storyinfo < 18)
+	{
+		trap_S_RegisterSound("sound/chars/kyle/21kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/22luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/luke/23luk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/24kyk001.mp3", qfalse);
+		trap_S_RegisterSound("sound/chars/kyle/25kyk001.mp3", qfalse);
+	}
+}
+
+/*
+===============
+WeaponMenu_Cache
+===============
+*/
+void WeaponMenu_Cache()
+{
+	trap_S_RegisterSound("sound/weapons/blaster/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/bowcaster/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/disruptor/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/demp2/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/thermal/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/detpack/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/flechette/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/repeater/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/concussion/select.mp3", qfalse);
+	trap_S_RegisterSound("sound/weapons/rocket/select.mp3", qfalse);
+}
+
+/*
+===============
+SaberMenu_Cache
+===============
+*/
+void SaberMenu_Cache()
+{
+	int index;
+
+	for (index = 1; index < 10; index++)
+	{
+		RE_RegisterModel(va("models/weapons2/saber_%d/saber_%d.glm", index, index));
+	}
+
+	for (index = 1; index < 6; index++)
+	{
+		RE_RegisterModel(va("models/weapons2/saber_dual_%d/saber_dual_%d.glm", index, index));
+	}
+}
+
 
 /*
 ===============
@@ -5335,6 +5430,24 @@ menuDef_t *Menus_ActivateByName(const char *p)
 			Menus[i].window.flags &= ~WINDOW_HASFOCUS;
 		}
 	}
+
+	SpeedrunPauseTimer(2);
+
+	if (!Q_stricmpn(p, "ingameMissionSelect", 19) || !Q_stricmp(p, "ingameGotoTier"))
+	{
+		MissionSelectMenu_Cache();
+		WeaponMenu_Cache();
+	}
+	else if (!Q_stricmp(p, "ingameWpnSelect"))
+	{
+		WeaponMenu_Cache();
+	}
+	else if (!Q_stricmp(p, "saberMenu"))
+	{
+		SaberMenu_Cache();
+	}
+
+	SpeedrunUnpauseTimer(2);
 
 
 	const int	com_demo = Cvar_VariableIntegerValue( "com_demo" );


### PR DESCRIPTION
# Issues
1. Mission info sounds (starting mission from menu), force status sounds (end of each missions tier) not precached.
2. Weapon selection sounds are not precached if player/npcs on completed map didn't have them (wpnselect menu).
3. Saber models not precached (saber menu after finishing tier2).

# Fixes
1. Precache force status sounds / mission information sounds conditionally on menus load (`UI_LoadMenus`).
2. Precache all weapon select sounds on menus load (`UI_LoadMenus`).
3. Precache saber models when map is "academy5" (`UI_LoadMenus`).