### PR TITLE
Fix not precached player items (full saves)

### DIFF
--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -2036,6 +2036,19 @@ Ghoul2 Insert End
 						CG_RegisterNPCCustomSounds( &g_entities[i].client->clientInfo );
 						//CG_RegisterNPCEffects( g_entities[i].client->playerTeam );
 					}
+					else
+					{
+						// precache player weapons. Since they can be missing from CS. Issue scenario: having eFULL of
+						// high-tier map, load eAUTO of low-tier map. Then load eFULL and make a new save. Now the save
+						// contains "broken" items CS.
+						for ( int wnum = 1 ; wnum < 16 ; wnum++ )
+						{
+							if ( g_entities[i].client->ps.stats[STAT_WEAPONS] & ( 1 << wnum ) )
+							{
+								CG_RegisterWeapon(wnum);
+							}
+						}
+					}
 				}
 			}
 			else if ( g_entities[i].svFlags & SVF_NPC_PRECACHE && g_entities[i].NPC_type && g_entities[i].NPC_type[0] )

--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -625,6 +625,10 @@ Player_CacheFromPrevLevel
 void Player_CacheFromPrevLevel(void)
 {
 	char	s[MAX_STRING_CHARS];
+
+	extern SavedGameJustLoaded_e g_eSavedGameJustLoaded;
+	// loading eFULL - sCVARNAME_PLAYERSAVE is stale, skip precaching
+	if (g_eSavedGameJustLoaded != eAUTO) return;
 	
 	gi.Cvar_VariableStringBuffer( sCVARNAME_PLAYERSAVE, s, sizeof(s) );
 	


### PR DESCRIPTION
# Issues
1. Player weapons not precached. Steps to reproduce:
  * Load level with high-tier weapons (e.g. kor1), make a save after loading.
  *  Load autosave of low-tier level (e.g. yavin2).
  * Load the save from step 1.
  * Make a new save. Now new save has broken config strings.
  * Now if your last loaded autosave is low-tier, loading the new save will cause unprecached player weapons loads.

2. Security key item not precached. To reproduce: load save of yavin2 (or other no key level) after loading autosave of t3_byss (or other key containing level, e.g. taspir2).

# Fixes
1. Precache all weapons player entity has (`ps.stats`) in `CG_RegisterGraphics`;
2. Avoid putting potentially stale player items from `sCVARNAME_PLAYERSAVE` cvar to `CS_ITEMS` when loading `eFULL` (`Player_CacheFromPrevLevel`).