### PR TITLE
Fix not precached NPC's assets

### DIFF
--- a/code/game/NPC_spawn.cpp
+++ b/code/game/NPC_spawn.cpp
@@ -1956,6 +1956,7 @@ extern void	NPC_PrecacheByClassName(const char*);
 void SP_NPC_spawner( gentity_t *self)
 {
 	extern void NPC_PrecacheAnimationCFG( const char *NPC_type );
+	extern void	CG_NPC_Precache(gentity_t*);
 	float	fDelay;
 
 	//register/precache the models needed for this NPC, not anymore
@@ -2034,10 +2035,10 @@ void SP_NPC_spawner( gentity_t *self)
 		}
 	}
 
-	if (!(self->svFlags&SVF_NPC_PRECACHE))
-	{
-		NPC_PrecacheByClassName(self->NPC_type);
-	}
+	// if (!(self->svFlags&SVF_NPC_PRECACHE))
+	// {
+		CG_NPC_Precache(self);
+	// }
 
 	//FIXME: store cameraGroup somewhere else and apply to spawned NPCs' cameraGroup
 	//Or just don't include NPC_spawners in cameraGroupings

--- a/code/game/NPC_spawn.cpp
+++ b/code/game/NPC_spawn.cpp
@@ -2035,10 +2035,8 @@ void SP_NPC_spawner( gentity_t *self)
 		}
 	}
 
-	// if (!(self->svFlags&SVF_NPC_PRECACHE))
-	// {
-		CG_NPC_Precache(self);
-	// }
+	// Changed from running only NPC_PrecacheByClassName to fix non-precached loads for Speed-Academy
+	CG_NPC_Precache(self);
 
 	//FIXME: store cameraGroup somewhere else and apply to spawned NPCs' cameraGroup
 	//Or just don't include NPC_spawners in cameraGroupings


### PR DESCRIPTION
# Issue
Not precached weapon models, saber skins, NPC sounds, effects when loading autosave / transitioning to most levels (yavin2, t1_rail, t1_sour, t1_surprise...).

# Fix
Substitute `NPC_PrecacheByClassName` with` CG_NPC_Precache` (`SP_NPC_spawner`), remove auto-spawners condition. Makes sure NPC assets are put to config strings beforehand so that then they are precached in `CG_RegisterGraphics`.
## Details
Game relies on precaching weapon/saber models, sounds by putting them to config strings instead of using actual caching functions. Since the `CG_NPC_Precache` is inside `CG_RegisterGraphics`, `SV_SetConfigstring` for assets is happening during `SS_GAME` therefore modified config strings arrive after first snapshot. So substituting config string setter functions with actual caching ones inside `CG_NPC_Precache` could work as well. But compared to `CG_NPC_Precache` inside `SP_NPC_spawner` that would miss auto-spawners caching (as they are already freed by the time `g_entities` cycle runs and they don't have `SVF_NPC_PRECACHE` flag).